### PR TITLE
Update bucket.tf

### DIFF
--- a/terraform/alicloud/bucket.tf
+++ b/terraform/alicloud/bucket.tf
@@ -3,6 +3,28 @@ resource "alicloud_oss_bucket" "bad_bucket" {
   # Versioning isn't enabled
   # Not Encrypted with a Customer Master Key and no Server side encryption
   # Doesn't have access logging enabled" 
+
+  bucket = "wildwestfreeforall"
+  acl    = "public-read-write"
+  tags = {
+    git_commit           = "9c114f23d311f787c137723e1f71b27a52f0adec"
+    git_file             = "terraform/alicloud/bucket.tf"
+    git_last_modified_at = "2022-04-05 15:17:55"
+    git_last_modified_by = "james.woolfenden@gmail.com"
+    git_modifiers        = "james.woolfenden"
+    git_org              = "bridgecrewio"
+    git_repo             = "terragoat"
+    yor_trace            = "80373049-248d-4f5e-9d25-740c3e80f2b9"
+  }
+}
+
+
+resource "alicloud_oss_bucket" "bad_bucket2" {
+  # Public and writeable bucket 
+  # Versioning isn't enabled
+  # Not Encrypted with a Customer Master Key and no Server side encryption
+  # Doesn't have access logging enabled" 
+
   bucket = "wildwestfreeforall"
   acl    = "public-read-write"
   tags = {


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Adds a new Alibaba Cloud OSS bucket resource named <code>bad_bucket2</code> with insecure configurations. The bucket is set to be publicly readable and writable, lacks versioning, encryption, and access logging. This change introduces potential security vulnerabilities in the infrastructure.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/jitsecurity-cto/terragoat/24?tool=ast&topic=Insecure+OSS+Bucket>Insecure OSS Bucket</a>
        </td><td>Creates a new Alibaba Cloud OSS bucket with insecure settings, potentially exposing data to unauthorized access and modifications.<details><summary>Modified files (1)</summary><ul><li>terraform/alicloud/bucket.tf</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>github-actions[bot]</td><td>Update-tags-by-Yor</td><td>April 06, 2022</td></tr>
<tr><td>JamesWoolfenden</td><td>Aligoat</td><td>April 05, 2022</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/jitsecurity-cto/terragoat/24?tool=ast&topic=Resource+Tagging>Resource Tagging</a>
        </td><td>Adds git-related tags to the new OSS bucket resource for tracking and management purposes.<details><summary>Modified files (1)</summary><ul><li>terraform/alicloud/bucket.tf</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>github-actions[bot]</td><td>Update-tags-by-Yor</td><td>April 06, 2022</td></tr>
<tr><td>JamesWoolfenden</td><td>Aligoat</td><td>April 05, 2022</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @Guy7B and the rest of your team on <a href=https://baz.co/changes/jitsecurity-cto/terragoat/24?tool=ast>(Baz)</a>.
    